### PR TITLE
Fix venues list in Print Hearing Lists

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.0.9'
+version '0.0.10'
 
 
 sourceCompatibility = '11.0'

--- a/src/main/java/uk/gov/hmcts/ecm/common/model/listing/ListingData.java
+++ b/src/main/java/uk/gov/hmcts/ecm/common/model/listing/ListingData.java
@@ -37,7 +37,7 @@ public class ListingData {
     @JsonProperty("listingDateTo")
     private String listingDateTo;
     @JsonProperty("listingVenue")
-    private String listingVenue;
+    private DynamicFixedListType listingVenue;
     @JsonProperty("listingCollection")
     private List<ListingTypeItem> listingCollection;
     @JsonProperty("listingVenueOfficeGlas")
@@ -94,6 +94,10 @@ public class ListingData {
         venueDundee = null;
         venueEdinburgh = null;
         clerkResponsible = null;
+    }
+
+    public boolean hasListingVenue() {
+        return listingVenue != null && listingVenue.getValue() != null;
     }
 }
 

--- a/src/test/java/uk/gov/hmcts/ecm/common/model/listing/ListingDataTest.java
+++ b/src/test/java/uk/gov/hmcts/ecm/common/model/listing/ListingDataTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.ecm.common.model.listing;
+
+import org.junit.Test;
+import uk.gov.hmcts.ecm.common.model.bulk.types.DynamicFixedListType;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ListingDataTest {
+
+    @Test
+    public void testHasListingVenueReturnsTrue() {
+        var listingData = new ListingData();
+        listingData.setListingVenue(new DynamicFixedListType("value"));
+
+        assertTrue(listingData.hasListingVenue());
+    }
+
+    @Test
+    public void testHasListingVenueReturnsFalseWhenSelectedValueIsNull() {
+        var listingData = new ListingData();
+        listingData.setListingVenue(new DynamicFixedListType());
+
+        assertFalse(listingData.hasListingVenue());
+    }
+
+    @Test
+    public void testHasListingVenueReturnsFalseWhenPropertyIsNull() {
+        var listingData = new ListingData();
+        listingData.setListingVenue(null);
+
+        assertFalse(listingData.hasListingVenue());
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-825


### Change description ###
Fix Print Hearing Lists event so that venues are shown for the managing office


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
