### PR TITLE
Remove redundant office number constants

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.0.31'
+version '0.0.32'
 
 sourceCompatibility = '11.0'
 

--- a/src/main/java/uk/gov/hmcts/ecm/common/model/helper/Constants.java
+++ b/src/main/java/uk/gov/hmcts/ecm/common/model/helper/Constants.java
@@ -122,9 +122,6 @@ public class Constants {
     public static final String RETURN_TRANSFER_EVENT_TRIGGER_ID = "returnCaseTransfer";
     public static final String CREATE_MULTIPLE_EVENT_TRIGGER_ID = "createMultiple";
 
-    public static final String ENGLANDWALES_OFFICE_NUMBER = "11";
-    public static final String SCOTLAND_OFFICE_NUMBER = "12";
-
     public static final String DEFAULT_SELECT_ALL_VALUE = "999999";
     public static final String SELECT_ALL_VALUE = "Select All";
     public static final String SELECT_NONE_VALUE = "None";


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-822


### Change description ###
Remove redundant office number constants for England/Wales and Scotland as these are no longer required for creating an Ethos Case Reference.
Breaking change - they also need removing from et-ccd-callbacks


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
