### PR TITLE
RET-5372 : Added multiples start bulk amend event method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'com.github.hmcts'
-version '2.3.1'
+version '2.4.0'
 
 java {
     toolchain {

--- a/src/main/java/uk/gov/hmcts/ecm/common/client/CaseDataBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ecm/common/client/CaseDataBuilder.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.et.common.model.ccd.CCDRequest;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.et.common.model.ccd.CaseDataContent;
 import uk.gov.hmcts.et.common.model.ccd.Event;
+import uk.gov.hmcts.et.common.model.generic.GenericRequest;
 import uk.gov.hmcts.et.common.model.multiples.MultipleData;
 
 import java.util.Map;
@@ -42,8 +43,8 @@ public class CaseDataBuilder {
         }), eventSummary, null);
     }
 
-    public CaseDataContent buildMultipleDataContent(MultipleData multipleData, CCDRequest req, String eventSummary) {
-        return getCaseDataContent(req, objectMapper.convertValue(multipleData, new TypeReference<>() {
+    public CaseDataContent buildMultipleDataContent(MultipleData mdata, GenericRequest req, String eventSummary) {
+        return getCaseDataContent(req, objectMapper.convertValue(mdata, new TypeReference<>() {
         }), eventSummary, null);
     }
 
@@ -53,7 +54,7 @@ public class CaseDataBuilder {
         }), updateChangeOrgSummary, null);
     }
 
-    private CaseDataContent getCaseDataContent(CCDRequest req, Map<String, JsonNode> data, String eventSummary,
+    private CaseDataContent getCaseDataContent(GenericRequest req, Map<String, JsonNode> data, String eventSummary,
                                                String eventDescription) {
         var event = Event.builder()
                 .eventId(req.getEventId())

--- a/src/main/java/uk/gov/hmcts/ecm/common/client/CcdClient.java
+++ b/src/main/java/uk/gov/hmcts/ecm/common/client/CcdClient.java
@@ -47,8 +47,10 @@ import uk.gov.hmcts.et.common.model.ccd.CaseUserAssignmentData;
 import uk.gov.hmcts.et.common.model.ccd.GenericTypeCaseDetails;
 import uk.gov.hmcts.et.common.model.ccd.PaginatedSearchMetadata;
 import uk.gov.hmcts.et.common.model.ccd.SubmitEvent;
+import uk.gov.hmcts.et.common.model.generic.GenericRequest;
 import uk.gov.hmcts.et.common.model.multiples.MultipleCaseSearchResult;
 import uk.gov.hmcts.et.common.model.multiples.MultipleData;
+import uk.gov.hmcts.et.common.model.multiples.MultipleRequest;
 import uk.gov.hmcts.et.common.model.multiples.SubmitMultipleEvent;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 
@@ -751,6 +753,14 @@ public class CcdClient {
         return restTemplate.exchange(uri, HttpMethod.GET, request, CCDRequest.class).getBody();
     }
 
+    public MultipleRequest startBulkAmendEventForMultiple(String authToken, String caseTypeId, String jur, String cid)
+        throws IOException {
+        HttpEntity<String> request = new HttpEntity<>(buildHeaders(authToken));
+        String uri = ccdClientConfig.buildStartEventForBulkAmendCaseUrl(userService.getUserDetails(authToken).getUid(),
+            jur, caseTypeId, cid);
+        return restTemplate.exchange(uri, HttpMethod.GET, request, MultipleRequest.class).getBody();
+    }
+
     public CCDRequest startDisposeEventForCase(String authToken, String caseTypeId, String jurisdiction, String cid)
             throws IOException {
         HttpEntity<String> request =
@@ -796,7 +806,7 @@ public class CcdClient {
     }
 
     public SubmitMultipleEvent submitMultipleEventForCase(String authToken, MultipleData multipleData,
-                                                          String caseTypeId, String jurisdiction, CCDRequest req,
+                                                          String caseTypeId, String jurisdiction, GenericRequest req,
                                                           String cid) throws IOException {
         HttpEntity<CaseDataContent> request =
                 new HttpEntity<>(caseDataBuilder.buildMultipleDataContent(multipleData, req, UPDATE_BULK_EVENT_SUMMARY),


### PR DESCRIPTION
Added a new method, startBulkAmendEventForMultiple, which allows for the starting of the event that returns the correct multiple case type object. Also updated CaseDataBuilder to use GenericRequest in places.

### Jira link

https://tools.hmcts.net/jira/browse/RET-5372)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
